### PR TITLE
Pakit config

### DIFF
--- a/.pakit.json
+++ b/.pakit.json
@@ -1,4 +1,5 @@
 {
+  "multiprocess": 2,
   "remove": [],
   "excludes": [],
   "extensions": ["js", "css", "json"],

--- a/src/pakit.js
+++ b/src/pakit.js
@@ -4,6 +4,8 @@ var resolve = require("resolve");
 var handlebars = require("handlebars");
 var utils = require("belty");
 var cwd = process.cwd();
+var localPakitConfigPath = path.join(cwd, ".pakit");
+var localBundlerrcPath = path.join(cwd, ".bundlerrc");
 
 var Bitbundler = requireModule("bit-bundler");
 var minify = requireModule("bit-bundler-minifyjs");
@@ -19,10 +21,18 @@ catch (e) { }
 try { eslint = require("eslint"); }
 catch (e) { }
 
-// Config file
-var config = require(path.join(__dirname, "../", ".bundlerrc.json"));
-try { config = Object.assign({}, config, require(path.join(cwd, ".bundlerrc.json"))); }
-catch (e) { }
+/// Config file
+var config = require(path.join(__dirname, "../", ".pakit"));
+
+/// Assign only if it exists.
+if (fs.existsSync(localPakitConfigPath+".json") || fs.existsSync(localPakitConfigPath+".js")) {
+  Object.assign(config, require(localPakitConfigPath));
+}
+
+/// This is for legacy but it is deprecated. Use .pakit
+if (fs.existsSync(localBundlerrcPath+".json") || fs.existsSync(localBundlerrcPath+".js")) {
+  Object.assign(config, require(localBundlerrcPath));
+}
 
 var defaultLoaderPlugins = [
   "excludes",

--- a/src/pakit.js
+++ b/src/pakit.js
@@ -29,11 +29,6 @@ if (fs.existsSync(localPakitConfigPath+".json") || fs.existsSync(localPakitConfi
   Object.assign(config, require(localPakitConfigPath));
 }
 
-/// This is for legacy but it is deprecated. Use .pakit
-if (fs.existsSync(localBundlerrcPath+".json") || fs.existsSync(localBundlerrcPath+".js")) {
-  Object.assign(config, require(localBundlerrcPath));
-}
-
 var defaultLoaderPlugins = [
   "excludes",
   "extensions",


### PR DESCRIPTION
BREAKING

1. Changed the name of the configuration file to `.pakit.json` or `pakit.js`.

2. changed how configurations are loaded so that invalid configuration files do report errors when invalid are provided, parsing errors can be reported